### PR TITLE
cntk 2.0 can't be found

### DIFF
--- a/dl_workshop_ec2.yml
+++ b/dl_workshop_ec2.yml
@@ -89,7 +89,7 @@ dependencies:
   - zict=0.1.3=py35h29275ca_0
   - zlib=1.2.11=ha838bed_2
   - pip:
-    - cntk==2.0
+    - cntk==2.5
     - opencv-python==3.4.0.12
 prefix: /home/ec2-user/src/anaconda3/envs/dl_workshop
 


### PR DESCRIPTION
@humayun 

This change makes the env creation work. It doesn't work without it.